### PR TITLE
Introduce simple NumberCollectionBuilder to simplify collection creation

### DIFF
--- a/src/SimplePHPEasyPlus/Number/CollectionItemNumberProxyFactory.php
+++ b/src/SimplePHPEasyPlus/Number/CollectionItemNumberProxyFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SimplePHPEasyPlus\Number;
+
+class CollectionItemNumberProxyFactory implements CollectionItemNumberProxyFactoryInterface
+{
+    public function createCollectionItem(NumberInterface $number)
+    {
+        return new CollectionItemNumberProxy($number);
+    }
+}

--- a/src/SimplePHPEasyPlus/Number/CollectionItemNumberProxyFactoryInterface.php
+++ b/src/SimplePHPEasyPlus/Number/CollectionItemNumberProxyFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SimplePHPEasyPlus\Number;
+
+interface CollectionItemNumberProxyFactoryInterface
+{
+    public function createCollectionItem(NumberInterface $number);
+}

--- a/src/SimplePHPEasyPlus/Number/NumberCollectionBuilder.php
+++ b/src/SimplePHPEasyPlus/Number/NumberCollectionBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SimplePHPEasyPlus\Number;
+
+use SimplePHPEasyPlus\Parser\SimpleNumberStringParserFactoryInterface;
+
+class NumberCollectionBuilder
+{
+    private $parserFactory;
+    private $simpleNumberFactory;
+    private $collectionItemNumberProxyFactory;
+    private $stringNumbers = array();
+
+    public function __construct(
+        SimpleNumberStringParserFactoryInterface $parserFactory,
+        NumberFactoryInterface $simpleNumberFactory,
+        CollectionItemNumberProxyFactoryInterface $collectionItemNumberProxyFactory
+    ) {
+        $this->parserFactory = $parserFactory;
+        $this->simpleNumberFactory = $simpleNumberFactory;
+        $this->collectionItemNumberProxyFactory = $collectionItemNumberProxyFactory;
+    }
+
+    public function add($stringNumber)
+    {
+        $this->stringNumbers[] = $stringNumber;
+    }
+
+    public function resolve()
+    {
+        $numberCollection = new NumberCollection();
+
+        foreach ($this->stringNumbers as $stringNumber) {
+            $parser = $this->parserFactory->createParser();
+            $parsed = $parser->parse($stringNumber);
+
+            $number = $this->simpleNumberFactory->createNumber($parsed);
+            $collectionItem = $this->collectionItemNumberProxyFactory->createCollectionItem($number);
+
+            $numberCollection->add($collectionItem);
+        }
+
+        return $numberCollection;
+    }
+}

--- a/src/SimplePHPEasyPlus/Number/NumberFactoryInterface.php
+++ b/src/SimplePHPEasyPlus/Number/NumberFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SimplePHPEasyPlus\Number;
+
+interface NumberFactoryInterface
+{
+    public function createNumber($value);
+}

--- a/src/SimplePHPEasyPlus/Number/SimpleNumberFactory.php
+++ b/src/SimplePHPEasyPlus/Number/SimpleNumberFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SimplePHPEasyPlus\Number;
+
+class SimpleNumberFactory implements NumberFactoryInterface
+{
+    public function createNumber($value)
+    {
+        return new SimpleNumber($value);
+    }
+}

--- a/src/SimplePHPEasyPlus/Parser/SimpleNumberStringParserFactory.php
+++ b/src/SimplePHPEasyPlus/Parser/SimpleNumberStringParserFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SimplePHPEasyPlus\Parser;
+
+class SimpleNumberStringParserFactory implements SimpleNumberStringParserFactoryInterface
+{
+    public function createParser()
+    {
+        return new SimpleNumberStringParser();
+    }
+}

--- a/src/SimplePHPEasyPlus/Parser/SimpleNumberStringParserFactoryInterface.php
+++ b/src/SimplePHPEasyPlus/Parser/SimpleNumberStringParserFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SimplePHPEasyPlus\Parser;
+
+interface SimpleNumberStringParserFactoryInterface
+{
+    public function createParser();
+}

--- a/tests/Functional/NumberCollectionBuilderTest.php
+++ b/tests/Functional/NumberCollectionBuilderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use SimplePHPEasyPlus\Number\NumberCollection;
+use SimplePHPEasyPlus\Number\SimpleNumber;
+use SimplePHPEasyPlus\Number\CollectionItemNumberProxy;
+use SimplePHPEasyPlus\Number\NumberCollectionBuilder;
+use SimplePHPEasyPlus\Number\SimpleNumberFactory;
+use SimplePHPEasyPlus\Number\CollectionItemNumberProxyFactory;
+use SimplePHPEasyPlus\Parser\SimpleNumberStringParserFactory;
+
+class NumberCollectionBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNumberCollectionBuilding()
+    {
+        $numberCollectionBuilder = new NumberCollectionBuilder(
+            new SimpleNumberStringParserFactory(),
+            new SimpleNumberFactory(),
+            new CollectionItemNumberProxyFactory()
+        );
+        $numberCollectionBuilder->add('2');
+        $numberCollectionBuilder->add('3');
+
+        $numberCollection = $numberCollectionBuilder->resolve();
+
+        $expected = new NumberCollection();
+        $expected->add(new CollectionItemNumberProxy(new SimpleNumber(2.0)));
+        $expected->add(new CollectionItemNumberProxy(new SimpleNumber(3.0)));
+        $this->assertEquals($expected, $numberCollection);
+    }
+}

--- a/tests/Number/NumberCollectionBuilderTest.php
+++ b/tests/Number/NumberCollectionBuilderTest.php
@@ -6,7 +6,7 @@ class NumberCollectionBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function testResolveShouldCallFactoriesForEachNumber()
     {
-        $parser = $this->getMock('SimplePHPEasyPlus\Parser\SimpleNumberStringParser');
+        $parser = $this->getMock('SimplePHPEasyPlus\Parser\SimpleNumberStringParserInterface');
         $parser->expects($this->at(0))
                ->method('parse')
                ->with('2')

--- a/tests/Number/NumberCollectionBuilderTest.php
+++ b/tests/Number/NumberCollectionBuilderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SimplePHPEasyPlus\Number;
+
+class NumberCollectionBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResolveShouldCallFactoriesForEachNumber()
+    {
+        $parser = $this->getMock('SimplePHPEasyPlus\Parser\SimpleNumberStringParser');
+        $parser->expects($this->at(0))
+               ->method('parse')
+               ->with('2')
+               ->will($this->returnValue(2.0));
+        $parser->expects($this->at(1))
+               ->method('parse')
+               ->with('3')
+               ->will($this->returnValue(3.0));
+
+        $parserFactory = $this->getMock('SimplePHPEasyPlus\Parser\SimpleNumberStringParserFactoryInterface');
+        $parserFactory->expects($this->exactly(2))
+                      ->method('createParser')
+                      ->will($this->returnValue($parser));
+
+        $numberFactory = $this->getMock('SimplePHPEasyPlus\Number\NumberFactoryInterface');
+        $numberFactory->expects($this->at(0))
+                      ->method('createNumber')
+                      ->with(2.0)
+                      ->will($this->returnValue(new SimpleNumber(2.0)));
+        $numberFactory->expects($this->at(1))
+                      ->method('createNumber')
+                      ->with(3.0)
+                      ->will($this->returnValue(new SimpleNumber(3.0)));
+
+        $collectionItemNumberProxyFactory = $this->getMock('SimplePHPEasyPlus\Number\CollectionItemNumberProxyFactoryInterface');
+        $collectionItemNumberProxyFactory->expects($this->at(0))
+                                         ->method('createCollectionItem')
+                                         ->with(new SimpleNumber(2.0))
+                                         ->will($this->returnValue(new CollectionItemNumberProxy(new SimpleNumber(2.0))));
+        $collectionItemNumberProxyFactory->expects($this->at(1))
+                                         ->method('createCollectionItem')
+                                         ->with(new SimpleNumber(3.0))
+                                         ->will($this->returnValue(new CollectionItemNumberProxy(new SimpleNumber(3.0))));
+
+        $numberCollectionBuilder = new NumberCollectionBuilder(
+            $parserFactory,
+            $numberFactory,
+            $collectionItemNumberProxyFactory
+        );
+        $numberCollectionBuilder->add('2');
+        $numberCollectionBuilder->add('3');
+
+        $numberCollection = $numberCollectionBuilder->resolve();
+    }
+}


### PR DESCRIPTION
This CollectionBuilder can take factories for the SimpleNumberStringParser,
the Number (usually a SimpleNumberFactory) and the CollectionItemNumberProxy.

For each added number, it will get an instance of each of these from the
factory, to build the CollectionItems that are then added to the
NumberCollection.

This change includes full test coverage.

This should vastly simplify the construction of NumberCollections.

Sample usage:

```
$numberCollectionBuilder = new NumberCollectionBuilder(
    new SimpleNumberStringParserFactory(),
    new SimpleNumberFactory(),
    new CollectionItemNumberProxyFactory()
);
$numberCollectionBuilder->add('2');
$numberCollectionBuilder->add('3');

$numberCollection = $numberCollectionBuilder->resolve();
```
