### PR TITLE
Add a Symfony2 bundle to integrate with the Symfony2 Dependency Injection Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "require-dev": {
+        "symfony/framework-bundle": "~2.1"
+    },
     "autoload": {
         "psr-0": { "SimplePHPEasyPlus": "src" }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,724 @@
+{
+    "hash": "37d2bd877e2ae1e356bed567a0ca70fd",
+    "packages": [
+
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/common",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common",
+                "reference": "2.3.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/doctrine/common/zipball/2.3.0",
+                "reference": "2.3.0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/"
+                },
+                {
+                    "name": "Christoph Dorn",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "http://jmsyst.com",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2012-09-19 22:55:18"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/php-fig/log/archive/1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/Config",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Config.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-02-17 12:27:42"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/DependencyInjection",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/DependencyInjection.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/config": ">=2.2,<2.3-dev",
+                "symfony/yaml": ">=2.0,<3.0"
+            },
+            "suggest": {
+                "symfony/config": "2.2.*",
+                "symfony/yaml": "2.2.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-02-11 11:43:49"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/EventDispatcher",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/dependency-injection": ">=2.0,<3.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "2.2.*",
+                "symfony/http-kernel": "2.2.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-02-11 11:26:43"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/Filesystem",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-01-17 15:25:59"
+        },
+        {
+            "name": "symfony/framework-bundle",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Bundle/FrameworkBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/FrameworkBundle.git",
+                "reference": "v2.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/FrameworkBundle/zipball/v2.2.0",
+                "reference": "v2.2.0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.2,<3.0",
+                "php": ">=5.3.3",
+                "symfony/config": ">=2.2,<2.3-dev",
+                "symfony/dependency-injection": ">=2.0,<3.0",
+                "symfony/event-dispatcher": ">=2.1,<3.0",
+                "symfony/filesystem": ">=2.1,<2.3-dev",
+                "symfony/http-kernel": ">=2.2,<2.3-dev",
+                "symfony/routing": ">=2.2,<2.3-dev",
+                "symfony/stopwatch": ">=2.2,<2.3-dev",
+                "symfony/templating": ">=2.1,<3.0",
+                "symfony/translation": ">=2.2,<2.3-dev"
+            },
+            "require-dev": {
+                "symfony/finder": ">=2.0,<3.0",
+                "symfony/security": ">=2.2,<2.3-dev"
+            },
+            "suggest": {
+                "symfony/console": "2.2.*",
+                "symfony/finder": "2.2.*",
+                "symfony/form": "2.2.*",
+                "symfony/validator": "2.2.*"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Bundle\\FrameworkBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony FrameworkBundle",
+            "homepage": "http://symfony.com",
+            "time": "2013-03-01 06:43:14"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/HttpFoundation",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/HttpFoundation.git",
+                "reference": "v2.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/v2.2.0",
+                "reference": "v2.2.0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "classmap": [
+                    "Symfony/Component/HttpFoundation/Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-02-26 09:42:13"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/HttpKernel",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/HttpKernel.git",
+                "reference": "v2.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/v2.2.0",
+                "reference": "v2.2.0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "psr/log": ">=1.0,<2.0",
+                "symfony/event-dispatcher": ">=2.1,<3.0",
+                "symfony/http-foundation": ">=2.2,<2.3-dev"
+            },
+            "require-dev": {
+                "symfony/browser-kit": "2.2.*",
+                "symfony/class-loader": ">=2.1,<3.0",
+                "symfony/config": ">=2.0,<3.0",
+                "symfony/console": "2.2.*",
+                "symfony/dependency-injection": ">=2.0,<3.0",
+                "symfony/finder": ">=2.0,<3.0",
+                "symfony/process": ">=2.0,<3.0",
+                "symfony/routing": ">=2.2,<2.3-dev",
+                "symfony/stopwatch": ">=2.2,<2.3-dev"
+            },
+            "suggest": {
+                "symfony/browser-kit": "2.2.*",
+                "symfony/class-loader": "2.2.*",
+                "symfony/config": "2.2.*",
+                "symfony/console": "2.2.*",
+                "symfony/dependency-injection": "2.2.*",
+                "symfony/finder": "2.2.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpKernel Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-03-01 06:52:29"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/Routing",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Routing.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Routing/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "doctrine/common": ">=2.2,<3.0",
+                "psr/log": ">=1.0,<2.0",
+                "symfony/config": ">=2.2,<2.3-dev",
+                "symfony/yaml": ">=2.0,<3.0"
+            },
+            "suggest": {
+                "doctrine/common": "~2.2",
+                "symfony/config": "2.2.*",
+                "symfony/yaml": "2.2.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Routing\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Routing Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-02-11 11:24:47"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/Stopwatch",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Stopwatch.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-01-04 16:58:00"
+        },
+        {
+            "name": "symfony/templating",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/Templating",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Templating.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Templating/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Templating\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Templating Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-01-17 15:25:59"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v2.2.0",
+            "target-dir": "Symfony/Component/Translation",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Translation.git",
+                "reference": "v2.2.0-RC3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/v2.2.0-RC3",
+                "reference": "v2.2.0-RC3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/config": ">=2.0,<2.3-dev",
+                "symfony/yaml": ">=2.2,<3.0"
+            },
+            "suggest": {
+                "symfony/config": "2.2.*",
+                "symfony/yaml": "2.2.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Translation Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-02-08 16:10:57"
+        }
+    ],
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": [
+
+    ],
+    "platform": [
+
+    ],
+    "platform-dev": [
+
+    ]
+}

--- a/src/SimplePHPEasyPlus/Bundle/DependencyInjection/Configuration.php
+++ b/src/SimplePHPEasyPlus/Bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SimplePHPEasyPlus\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('simple_php_easy_plus');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/SimplePHPEasyPlus/Bundle/DependencyInjection/SimplePHPEasyPlusExtension.php
+++ b/src/SimplePHPEasyPlus/Bundle/DependencyInjection/SimplePHPEasyPlusExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SimplePHPEasyPlus\Bundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class SimplePHPEasyPlusExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/src/SimplePHPEasyPlus/Bundle/Resources/config/services.xml
+++ b/src/SimplePHPEasyPlus/Bundle/Resources/config/services.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="simple_php_easy_plus.number_collection_builder.class">SimplePHPEasyPlus\Number\NumberCollectionBuilder</parameter>
+        <parameter key="simple_php_easy_plus.parser.simple_number_string_parser_factory.class">SimplePHPEasyPlus\Parser\SimpleNumberStringParserFactory</parameter>
+        <parameter key="simple_php_easy_plus.number.number_factory.class">SimplePHPEasyPlus\Number\SimpleNumberFactory</parameter>
+        <parameter key="simple_php_easy_plus.number.collection_item_number_proxy_factory.class">SimplePHPEasyPlus\Number\CollectionItemNumberProxyFactory</parameter>
+
+        <parameter key="simple_php_easy_plus.engine.class">SimplePHPEasyPlus\Engine</parameter>
+        <parameter key="simple_php_easy_plus.operation.class">SimplePHPEasyPlus\Operation\ArithmeticOperation</parameter>
+        <parameter key="simple_php_easy_plus.operator.addition.class">SimplePHPEasyPlus\Operator\AdditionOperator</parameter>
+        <parameter key="simple_php_easy_plus.operator.number.class">SimplePHPEasyPlus\Number\SimpleNumber</parameter>
+
+        <parameter key="simple_php_easy_plus.runner.class">SimplePHPEasyPlus\Calcul\CalculRunner</parameter>
+    </parameters>
+
+    <services>
+        <service id="simple_php_easy_plus.number_collection_builder" class="%simple_php_easy_plus.number_collection_builder.class%">
+            <argument type="service" id="simple_php_easy_plus.parser.simple_number_string_parser_factory"/>
+            <argument type="service" id="simple_php_easy_plus.number.number_factory"/>
+            <argument type="service" id="simple_php_easy_plus.number.collection_item_number_proxy_factory"/>
+        </service>
+
+        <service id="simple_php_easy_plus.engine" class="%simple_php_easy_plus.engine.class%">
+            <argument type="service" id="simple_php_easy_plus.operation"/>
+        </service>
+
+        <service id="simple_php_easy_plus.runner" class="%simple_php_easy_plus.runner.class%"></service>
+
+        <service id="simple_php_easy_plus.parser.simple_number_string_parser_factory" class="%simple_php_easy_plus.parser.simple_number_string_parser_factory.class%" public="false"></service>
+        <service id="simple_php_easy_plus.number.number_factory" class="%simple_php_easy_plus.number.number_factory.class%" public="false"></service>
+        <service id="simple_php_easy_plus.number.collection_item_number_proxy_factory" class="%simple_php_easy_plus.number.collection_item_number_proxy_factory.class%" public="false"></service>
+
+        <service id="simple_php_easy_plus.operation" class="%simple_php_easy_plus.operation.class%" public="false">
+            <argument type="service" id="simple_php_easy_plus.operator.addition"/>
+        </service>
+
+        <service id="simple_php_easy_plus.operator.addition" class="%simple_php_easy_plus.operator.addition.class%" public="false">
+            <argument>%simple_php_easy_plus.operator.number.class%</argument>
+        </service>
+    </services>
+</container>

--- a/src/SimplePHPEasyPlus/Bundle/Resources/config/services.xml
+++ b/src/SimplePHPEasyPlus/Bundle/Resources/config/services.xml
@@ -19,7 +19,7 @@
     </parameters>
 
     <services>
-        <service id="simple_php_easy_plus.number_collection_builder" class="%simple_php_easy_plus.number_collection_builder.class%">
+        <service id="simple_php_easy_plus.number_collection_builder" class="%simple_php_easy_plus.number_collection_builder.class%" scope="prototype">
             <argument type="service" id="simple_php_easy_plus.parser.simple_number_string_parser_factory"/>
             <argument type="service" id="simple_php_easy_plus.number.number_factory"/>
             <argument type="service" id="simple_php_easy_plus.number.collection_item_number_proxy_factory"/>

--- a/src/SimplePHPEasyPlus/Bundle/SimplePHPEasyPlusBundle.php
+++ b/src/SimplePHPEasyPlus/Bundle/SimplePHPEasyPlusBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SimplePHPEasyPlus\Bundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class SimplePHPEasyPlusBundle extends Bundle
+{
+}

--- a/tests/Bundle/ExtensionTest.php
+++ b/tests/Bundle/ExtensionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SimplePHPEasyPlus\Bundle;
+
+use SimplePHPEasyPlus\Bundle\DependencyInjection\SimplePHPEasyPlusExtension;
+use SimplePHPEasyPlus\Calcul\Calcul;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testContainerConfig()
+    {
+        $extension = new SimplePHPEasyPlusExtension();
+
+        $container = new ContainerBuilder();
+        $extension->load(array(), $container);
+
+        $collectionBuilder = $container->get('simple_php_easy_plus.number_collection_builder');
+        $this->assertInstanceOf('SimplePHPEasyPlus\Number\NumberCollectionBuilder', $collectionBuilder);
+
+        $engine = $container->get('simple_php_easy_plus.engine');
+        $this->assertInstanceOf('SimplePHPEasyPlus\Engine', $engine);
+
+        $runner = $container->get('simple_php_easy_plus.runner');
+        $this->assertInstanceOf('SimplePHPEasyPlus\Calcul\CalculRunner', $runner);
+
+        $collectionBuilder->add('1');
+        $collectionBuilder->add('2');
+
+        $calcul = new Calcul($engine, $collectionBuilder->resolve());
+        $runner->run($calcul);
+
+        $this->assertEquals(3, $calcul->getResult()->getValue());
+    }
+}

--- a/tests/Bundle/ExtensionTest.php
+++ b/tests/Bundle/ExtensionTest.php
@@ -32,4 +32,18 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(3, $calcul->getResult()->getValue());
     }
+
+    /** @test */
+    public function numberCollectionBuilderShouldHavePrototypeScope()
+    {
+        $container = new ContainerBuilder();
+
+        $extension = new SimplePHPEasyPlusExtension();
+        $extension->load(array(), $container);
+
+        $builder1 = $container->get('simple_php_easy_plus.number_collection_builder');
+        $builder2 = $container->get('simple_php_easy_plus.number_collection_builder');
+
+        $this->assertNotSame($builder2, $builder1);
+    }
 }

--- a/tests/Bundle/ExtensionTest.php
+++ b/tests/Bundle/ExtensionTest.php
@@ -10,9 +10,9 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testContainerConfig()
     {
-        $extension = new SimplePHPEasyPlusExtension();
-
         $container = new ContainerBuilder();
+
+        $extension = new SimplePHPEasyPlusExtension();
         $extension->load(array(), $container);
 
         $collectionBuilder = $container->get('simple_php_easy_plus.number_collection_builder');


### PR DESCRIPTION
By having the bootstrap managed by the DIC, it becomes a lot easier to use. Also, the XML file is way more maintainable than the annoying manual construction of the object graph.

Sample usage:

```
$collectionBuilder = $container->get('simple_php_easy_plus.number_collection_builder');
$engine = $container->get('simple_php_easy_plus.engine');
$runner = $container->get('simple_php_easy_plus.runner');

$collectionBuilder->add('1');
$collectionBuilder->add('2');

$calcul = new Calcul($engine, $collectionBuilder->resolve());
$runner->run($calcul);

$value = $calcul->getResult()->getValue();
```

This PR depends on #13.
