### PR TITLE
Improve benchmark output for various runtimes

### DIFF
--- a/benchmark/simple.php
+++ b/benchmark/simple.php
@@ -66,4 +66,10 @@ for($i = 0 ; $i < $number ; ++$i) {
 $time2 = microtime(true) - $start;
 printf('    SimplePHPEasyPlus: %01.2f ms.%s', $time2*$number, "\n");
 
-printf('%s=> SimplePHPEasyPlus is %d slower than Native PHP%s', "\n", $time2/$time1, "\n");
+printf('%s=> ', "\n");
+if ($time2 >= $time1) {
+  printf('SimplePHPEasyPlus is %.1fx slower than Native PHP', $time2/$time1);
+} else {
+  printf('SimplePHPEasyPlus is %.1fx faster than Native PHP', $time1/$time2);
+}
+printf('%s', "\n");


### PR DESCRIPTION
On PHP systems and runtimes where SimplePHPEasyPlus is faster than native
PHP, the benchmark outputs misleading results:

``` php
$ php -f benchmark/simple.php
For 100000 additions:
    Native PHP "+" operator: 1810.69 ms.
    SimplePHPEasyPlus: 172.39 ms.

=> SimplePHPEasyPlus is 0 slower than Native PHP
```

Instead, when SimplePHPEasyPlus runs faster, tailor the message:

``` php
$ php -f benchmark/simple.php
For 100000 additions:
    Native PHP "+" operator: 1833.61 ms.
    SimplePHPEasyPlus: 169.83 ms.

=> SimplePHPEasyPlus is 10.8x faster than Native PHP
```

(I left the "... faster ..." and "... slower ..." strings separate to make it
easier to internationalize this code later.)
