### PR TITLE
Fixed typo "Excpected" -> "Expected"

### DIFF
--- a/tests/Number/NumberCollectionTest.php
+++ b/tests/Number/NumberCollectionTest.php
@@ -22,6 +22,6 @@ class NumberCollectionTest extends PHPUnit_Framework_TestCase
             return;
         }
 
-        $this->fail('Excpected out of range exception has not been raised.');
+        $this->fail('Expected out of range exception has not been raised.');
     }
 }


### PR DESCRIPTION
This patch fixes a typo in unit test NumberCollectionTest.php.
